### PR TITLE
Typo and rounding fix for Multishot Weapons

### DIFF
--- a/data/blueprints.xml.append
+++ b/data/blueprints.xml.append
@@ -2739,7 +2739,7 @@ The 4 artillery weapons traditionally deployed on a vessel like this have been s
 
   <augBlueprint name="RAD_WM_MULTISHOT">
     <title>Multishot Weapons</title>
-    <desc>Splits every projectile or beam you fire in two, however the hull damage, system damage, and ion damage are halved. In the case that the base value is odd, one projectile will have more damage than the other. When used with multishot all projectiles are doubled but retain their original damage.
+    <desc>Splits every projectile or beam you fire in two, however the hull damage, system damage, and ion damage are halved. In the case that the base value is odd, one projectile will have more damage than the other. When used with High Energy Weapons, all projectiles are doubled but retain their original damage.
     
 Can be installed internally for 20 scrap in the storage menu.</desc>
     <cost>60</cost>

--- a/data/rad_scripts/rad_functions.lua
+++ b/data/rad_scripts/rad_functions.lua
@@ -1620,9 +1620,9 @@ script.on_internal_event(Defines.InternalEvents.PROJECTILE_FIRE, function(projec
             newDamage.iIonDamage = damage.iIonDamage
             newDamage.iSystemDamage = damage.iSystemDamage
         else
-            newDamage.iDamage = math.ceil(damage.iDamage/2)
-            newDamage.iIonDamage = math.ceil(damage.iIonDamage/2)
-            newDamage.iSystemDamage = math.ceil(damage.iSystemDamage/2)
+            newDamage.iDamage = math.floor(damage.iDamage/2)
+            newDamage.iIonDamage = math.floor(damage.iIonDamage/2)
+            newDamage.iSystemDamage = math.floor(damage.iSystemDamage/2)
         end
 
         newDamage.fireChance = damage.fireChance


### PR DESCRIPTION
<ins>Current:</ins> 

1. The description of Multishot Weapons reads in part "When used with multishot all projectiles are doubled but retain their original damage".
2. The calculation logic for Multishot Weapons augment causes damage for the original projectile to be rounded up, as well as damage for the new projectile (created by the duplication effect of the augment.)

<ins>Proposed:</ins> 

1. Change description to read "when used with **High Energy Weapons**" (emphasis mine) to match the mod's calculation logic when both augments are present.
2. Change calculation logic for Multishot Weapons to round **down** damage for the original projectile; this maintains parity with how the augment treats damage from beam weapons (and is consistent with the augment's description.) (see #7)

Note that this does not address the potential for Multishot Weapons to behave unintuitively when base projectile damage is fractional.
